### PR TITLE
fix(docutils): use [latex writers] section

### DIFF
--- a/docutils.conf
+++ b/docutils.conf
@@ -1,4 +1,4 @@
-[latex2e writer]
+[latex writers]
 compound_enumerators = 1
 section_prefix_for_enumerators = 1
 section_enumerator_separator = .


### PR DESCRIPTION
Docutils recently (7 months ago) released an [update with a breaking change (0.20)](https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-20-2023-05-04) that ignores the `[latex2e writer]` config section when using the xetex writer. Settings should instead be placed in the `[latex writers]` section.

The [Github action workflow](https://github.com/syncs-usyd/syncs-constitution/blob/master/.github/workflows/makepdf.yml#L7) used to build the constitution PDF uses the `ubuntu-latest` image, which is [currently Ubuntu 22.04](https://github.com/actions/runner-images#available-images), which uses version 0.17.1 in its repos, so it still works but it **will break** when the `ubuntu-latest` image gets updated to use 0.20.x+.

Noble (Ubuntu 24.04, scheduled to be delivered as the next LTS release in 4 months) [currently is on 0.20.1](https://packages.ubuntu.com/search?keywords=python3-docutils+&searchon=names&suite=all&section=all)